### PR TITLE
Fix pdf.js worker resolution for SSR

### DIFF
--- a/ats.ts
+++ b/ats.ts
@@ -4,6 +4,7 @@
  */
 
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs'
+import { createRequire } from 'module'
 import { streamObject, generateObject, streamText, smoothStream } from 'ai'
 import { openai } from '@ai-sdk/openai'
 import FirecrawlApp from '@mendable/firecrawl-js'
@@ -11,6 +12,14 @@ import { z } from 'zod'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { toXML } from 'jstoxml'
+
+// Resolve the pdf.js worker to a stable path for both CLI and SSR builds.
+const require = createRequire(import.meta.url)
+const pdfWorkerSrc = require.resolve('pdfjs-dist/legacy/build/pdf.worker.mjs')
+
+if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
+  pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerSrc
+}
 
 
 // Simple interfaces - no over-engineering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobheist",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Plan the perfect job heist - outsmart ATS filters with AI-powered resume analysis",
   "main": "dist/ats.js",
   "types": "dist/ats.d.ts",


### PR DESCRIPTION
## Summary
- resolve the pdf.js worker path using `createRequire` so both CLI and SSR builds load the same file
- document the workerSrc guard so future changes keep SSR compatibility in mind
- bump the package version to 1.1.1 to ship the fix

## Testing
- pnpm build
